### PR TITLE
Refactoring encode decode method

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -56,40 +56,40 @@ class CeasarCipher {
     let mssg = message.toUpperCase();
     let shift = shift_length;
     let letter;
-    let cipherLetter;
     let alphabet = this.alphabet;
+    let cipherLetter;
+    let letterIndex;
+    let absIndex;
 
-    // Proxy is used to allow the use of negative array indexes in applyEncoding
-    let negIndexProxy = new Proxy(alphabet, {
-      get(targetLetter, prop) {
-        if (!isNaN(prop)) {
-          prop = parseInt(prop, 10);
-          if (prop < 0) {
-            prop += targetLetter.length;
-          }
-        }
-        return targetLetter[prop];
-      }
-    });
 
     for (letter of mssg) {
       // If the letter is in the alphabet (e.g. not a number, space or punctuation mark) then encode it
       if (alphabet.includes(letter)) {
 
-      // Get letter 3 letters before the letter used in the message
-      cipherLetter = negIndexProxy[alphabet.indexOf(letter) - shift];
+        // Get index of current letter
+        letterIndex = alphabet.indexOf(letter);
 
+          // If index is less than/equal to shift (n) - there is no letter n letters before it - so start again at Z
+          if (letterIndex <= shift) {
+
+            // Get the absolute value of the letter index - this will be a negative number
+            absIndex = Math.abs(letterIndex);
+
+            // Work backwards from Z to get the shifted letter
+            cipherLetter = alphabet[((alphabet.length - 1) - absIndex)];
+          }
+          // Else if index is greater than the shift (n) - take the letter n letters before it
+          else {
+            cipherLetter = alphabet[(alphabet.indexOf(letter) - shift)];
+          }
       // Replace original letter with the cipher letter
       mssg = mssg.replace(letter, cipherLetter);
       }
     }
-    return mssg
+    return mssg;
+    }
   }
 
-  applyDecoding (message =' ', shift_length = 3) {
-    break
-  }
-}
 
 // TODO: Write decoder method
 // TODO: Make the shift_length a property of the class that can be overwritten?

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,5 +1,4 @@
 // Ceasar Cipher class defined
-const chalk = require('chalk');
 
 /**
  * CeaserCipher replicates action of a shift cipher, aka. Ceasar cipher.


### PR DESCRIPTION
Added;
- Removed proxy object, and implemented manual method for calculating what the shifted letter would be for a letter at start of alphabet - essentially, instead of taking the letter n letters before (the 'shift'), you roll to the end of the alphabet - e.g. A becomes X with a shift of 3.
